### PR TITLE
Added localization and more flexibility regarding NSDateFormatters

### DIFF
--- a/MHPrettyDate.podspec
+++ b/MHPrettyDate.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/bobjustbob/MHPrettyDate.git", :tag => "v1.0.1" }
   s.platform     = :ios, '5.0'
   s.source_files = 'MHPrettyDate/**/*.{h,m}'
+  s.resources    = "#{s.name}/**/*.{lproj}"
   s.requires_arc = true
   s.framework  = 'Foundation'
 end

--- a/MHPrettyDate.xcodeproj/project.pbxproj
+++ b/MHPrettyDate.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CCEAF12516F3305C0049549E /* MHPrettyDate.strings in Resources */ = {isa = PBXBuildFile; fileRef = CCEAF12116F328480049549E /* MHPrettyDate.strings */; };
+		CCEAF12B16F3354E0049549E /* MHPrettyDate.strings in Resources */ = {isa = PBXBuildFile; fileRef = CCEAF12116F328480049549E /* MHPrettyDate.strings */; };
 		E9DC15FD15FBDF2600C594E6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9DC15FC15FBDF2600C594E6 /* Foundation.framework */; };
 		E9DC160215FBDF2600C594E6 /* MHPrettyDate.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E9DC160115FBDF2600C594E6 /* MHPrettyDate.h */; };
 		E9DC160415FBDF2600C594E6 /* MHPrettyDate.m in Sources */ = {isa = PBXBuildFile; fileRef = E9DC160315FBDF2600C594E6 /* MHPrettyDate.m */; };
@@ -49,6 +51,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		CCEAF12016F328480049549E /* en */ = {isa = PBXFileReference; lastKnownFileType = file; name = en; path = en.lproj/MHPrettyDate.strings; sourceTree = "<group>"; };
+		CCEAF12216F329270049549E /* nl */ = {isa = PBXFileReference; lastKnownFileType = file; name = nl; path = nl.lproj/MHPrettyDate.strings; sourceTree = "<group>"; };
 		E93DEE6D161AD591005B9E19 /* MHPrettyDateExampleApp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = MHPrettyDateExampleApp.xcodeproj; path = MHPrettyDateExampleApp/MHPrettyDateExampleApp.xcodeproj; sourceTree = "<group>"; };
 		E9DC15F915FBDF2600C594E6 /* libMHPrettyDate.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMHPrettyDate.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9DC15FC15FBDF2600C594E6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -130,6 +134,7 @@
 			children = (
 				E9DC160115FBDF2600C594E6 /* MHPrettyDate.h */,
 				E9DC160315FBDF2600C594E6 /* MHPrettyDate.m */,
+				CCEAF12116F328480049549E /* MHPrettyDate.strings */,
 				E9DC15FF15FBDF2600C594E6 /* Supporting Files */,
 			);
 			path = MHPrettyDate;
@@ -172,6 +177,7 @@
 				E9DC15F515FBDF2600C594E6 /* Sources */,
 				E9DC15F615FBDF2600C594E6 /* Frameworks */,
 				E9DC15F715FBDF2600C594E6 /* CopyFiles */,
+				CCEAF12A16F3353D0049549E /* Resources */,
 			);
 			buildRules = (
 			);
@@ -216,6 +222,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				nl,
 			);
 			mainGroup = E9DC15EE15FBDF2600C594E6;
 			productRefGroup = E9DC15FA15FBDF2600C594E6 /* Products */;
@@ -245,11 +252,20 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
+		CCEAF12A16F3353D0049549E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CCEAF12B16F3354E0049549E /* MHPrettyDate.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E9DC160715FBDF2600C594E6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				E9DC161815FBDF2600C594E6 /* InfoPlist.strings in Resources */,
+				CCEAF12516F3305C0049549E /* MHPrettyDate.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -299,6 +315,15 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		CCEAF12116F328480049549E /* MHPrettyDate.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CCEAF12016F328480049549E /* en */,
+				CCEAF12216F329270049549E /* nl */,
+			);
+			name = MHPrettyDate.strings;
+			sourceTree = "<group>";
+		};
 		E9DC161615FBDF2600C594E6 /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/MHPrettyDate/MHPrettyDate.h
+++ b/MHPrettyDate/MHPrettyDate.h
@@ -90,6 +90,8 @@ typedef enum
 @interface MHPrettyDate : NSObject
 
 +(NSString*) prettyDateFromDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat;
++(NSString*) prettyDateFromDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat withDateStyle:(NSDateFormatterStyle) dateStyle;
++(NSString*) prettyDateFromDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat withDateStyle:(NSDateFormatterStyle) dateStyle withTimeStyle:(NSDateFormatterStyle) timeStyle;
 +(BOOL)      isToday:(NSDate*)       date;
 // date
 +(BOOL)      isPastDate:(NSDate*)     date;

--- a/MHPrettyDate/MHPrettyDate.m
+++ b/MHPrettyDate/MHPrettyDate.m
@@ -122,7 +122,7 @@
     return [date1 isEqualToDate:date2];
 }
 
-+(NSString*) makePrettyDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat
++(NSString*) makePrettyDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat withDateStyle:(NSDateFormatterStyle) dateStyle withTimeStyle:(NSDateFormatterStyle)timeStyle
 {
    NSString* dateString;
    
@@ -131,7 +131,7 @@
       case MHPrettyDateFormatWithTime:
       case MHPrettyDateFormatNoTime:
       case MHPrettyDateFormatTodayTimeOnly:
-         dateString = [MHPrettyDate formattedStringForDate:date withFormat:dateFormat];
+         dateString = [MHPrettyDate formattedStringForDate:date withFormat:dateFormat withDateStyle:dateStyle withTimeStyle:timeStyle];
          break;
          
       case MHPrettyDateLongRelativeTime:
@@ -211,8 +211,18 @@
    return dateString;
 }
 
-// TODO: this method needs to be refactored and localized
 +(NSString*) formattedStringForDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat
+{
+    return [MHPrettyDate formattedStringForDate:date withFormat:dateFormat withDateStyle:NSDateFormatterShortStyle withTimeStyle:NSDateFormatterShortStyle];
+}
+
++(NSString*) formattedStringForDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat withDateStyle:(NSDateFormatterStyle) dateStyle
+{
+    return [MHPrettyDate formattedStringForDate:date withFormat:dateFormat withDateStyle:dateStyle withTimeStyle:NSDateFormatterShortStyle];
+}
+
+// TODO: this method needs to be refactored and localized
++(NSString*) formattedStringForDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat withDateStyle:(NSDateFormatterStyle) dateStyle withTimeStyle:(NSDateFormatterStyle) timeStyle
 {
     NSString*        dateString;
     NSDateFormatter* formatter   = [[NSDateFormatter alloc] init];
@@ -263,22 +273,19 @@
                 dateString = @"h:mm a";
             }
         }
+
+        [formatter setDateFormat: dateString];
+        return [formatter stringFromDate:date];
+    }
+    else if (dateFormat == MHPrettyDateFormatWithTime)
+    {
+        return [NSDateFormatter localizedStringFromDate:date dateStyle:dateStyle timeStyle:timeStyle];
+        
     }
     else
     {
-        if (dateFormat == MHPrettyDateFormatWithTime)
-        {
-            dateString = @"MM/dd/yy h:mm a"; // bjw bugbugbug need to localize
-        }
-        else
-        {
-            dateString = [NSDateFormatter dateFormatFromTemplate:@"MMddyy" options:0 locale:[NSLocale currentLocale]];
-        }
-    }
-    
-    [formatter setDateFormat: dateString];
-    
-    return [formatter stringFromDate:date];
+        return [NSDateFormatter localizedStringFromDate:date dateStyle:dateStyle timeStyle:NSDateFormatterNoStyle];
+    }    
 }
 
 
@@ -359,7 +366,17 @@
 
 +(NSString*) prettyDateFromDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat
 {
-    return [MHPrettyDate makePrettyDate:date withFormat:dateFormat];
+    return [MHPrettyDate makePrettyDate:date withFormat:dateFormat withDateStyle:NSDateFormatterShortStyle withTimeStyle:NSDateFormatterShortStyle];
+}
+
++(NSString*) prettyDateFromDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat withDateStyle:(NSDateFormatterStyle) dateStyle
+{
+    return [MHPrettyDate makePrettyDate:date withFormat:dateFormat withDateStyle:dateStyle withTimeStyle:NSDateFormatterShortStyle];
+}
+
++(NSString*) prettyDateFromDate:(NSDate*) date withFormat:(MHPrettyDateFormat) dateFormat withDateStyle:(NSDateFormatterStyle) dateStyle withTimeStyle:(NSDateFormatterStyle) timeStyle
+{
+    return [MHPrettyDate makePrettyDate:date withFormat:dateFormat withDateStyle:dateStyle withTimeStyle:timeStyle];
 }
 
 +(BOOL) willMakePretty:(NSDate *)date

--- a/MHPrettyDate/MHPrettyDate.m
+++ b/MHPrettyDate/MHPrettyDate.m
@@ -227,9 +227,6 @@
     NSString*        dateString;
     NSDateFormatter* formatter   = [[NSDateFormatter alloc] init];
     
-    //
-    // TODO: this needs to be localized
-    //
     if ([MHPrettyDate willMakePretty:date])
     {
         if ([MHPrettyDate isTomorrow:date])

--- a/MHPrettyDate/MHPrettyDate.m
+++ b/MHPrettyDate/MHPrettyDate.m
@@ -174,12 +174,12 @@
          
          if (minutes == 0)
          {
-            dateString = @"Now";
+            dateString = NSLocalizedStringFromTable(@"Now", @"MHPrettyDate", nil);
          }
          else
          {
-            if (minutes == 1) post = (dateFormat == MHPrettyDateLongRelativeTime) ? @" minute ago" : @"m";
-            else post = (dateFormat == MHPrettyDateLongRelativeTime) ? @" minutes ago" : @"m";
+            if (minutes == 1) post = (dateFormat == MHPrettyDateLongRelativeTime) ? NSLocalizedStringFromTable(@" minute ago", @"MHPrettyDate", nil) : NSLocalizedStringFromTable(@"m", @"MHPrettyDate", nil);
+            else post = (dateFormat == MHPrettyDateLongRelativeTime) ? NSLocalizedStringFromTable(@" minutes ago", @"MHPrettyDate", nil) : NSLocalizedStringFromTable(@"m", @"MHPrettyDate", nil);
             dateString = [NSString stringWithFormat: @"%d%@", minutes, post];
          }
       }
@@ -189,14 +189,14 @@
          NSInteger hours = [prettyDate hoursFromNow: date] * -1;
          NSString  *post;
          
-         if (hours == 1) post = (dateFormat == MHPrettyDateLongRelativeTime) ? @" hour ago" : @"h";
-         else post = (dateFormat == MHPrettyDateLongRelativeTime) ? @" hours ago" : @"h";
+         if (hours == 1) post = (dateFormat == MHPrettyDateLongRelativeTime) ? NSLocalizedStringFromTable(@" hour ago", @"MHPrettyDate", nil) : NSLocalizedStringFromTable(@"h", @"MHPrettyDate", nil);
+         else post = (dateFormat == MHPrettyDateLongRelativeTime) ? NSLocalizedStringFromTable(@" hours ago", @"MHPrettyDate", nil) : NSLocalizedStringFromTable(@"h", @"MHPrettyDate", nil);
          dateString = [NSString stringWithFormat: @"%d%@", hours, post];
       }
    }
    else if ([MHPrettyDate isYesterday:date])
    {
-      dateString = (dateFormat == MHPrettyDateLongRelativeTime) ? @"1 day ago" : @"1d";
+      dateString = (dateFormat == MHPrettyDateLongRelativeTime) ? NSLocalizedStringFromTable(@"1 day ago", @"MHPrettyDate", nil) : NSLocalizedStringFromTable(@"1d", @"MHPrettyDate", nil);
    }
    else
    {
@@ -204,7 +204,7 @@
       NSInteger days = [prettyDate daysFromNow: date] * -1;
       NSString  *post;
       
-      post = (dateFormat == MHPrettyDateLongRelativeTime) ? @" days ago" : @"d";
+      post = (dateFormat == MHPrettyDateLongRelativeTime) ? NSLocalizedStringFromTable(@" days ago", @"MHPrettyDate", nil) : NSLocalizedStringFromTable(@"d", @"MHPrettyDate", nil);
       dateString = [NSString stringWithFormat: @"%d%@", days, post];
    }
    
@@ -234,15 +234,15 @@
     {
         if ([MHPrettyDate isTomorrow:date])
         {
-            dateString = @"'Tomorrow'";
+            dateString = NSLocalizedStringFromTable(@"'Tomorrow'", @"MHPrettyDate", @"This value is used in a DateFormat, the single quotes are important.");
         }
         else if ([MHPrettyDate isToday:date])
         {
-            dateString = @"'Today'";
+            dateString = NSLocalizedStringFromTable(@"'Today'", @"MHPrettyDate", @"This value is used in a DateFormat, the single quotes are important.");
         }
         else if ([MHPrettyDate isYesterday:date])
         {
-            dateString = @"'Yesterday'";
+            dateString = NSLocalizedStringFromTable(@"'Yesterday'", @"MHPrettyDate", @"This value is used in a DateFormat, the single quotes are important.");
         }
         else
         {

--- a/MHPrettyDate/en.lproj/MHPrettyDate.strings
+++ b/MHPrettyDate/en.lproj/MHPrettyDate.strings
@@ -1,0 +1,66 @@
+//
+//  MHPrettyDate.strings
+//  MHPrettyDate
+//
+//  Created by Bart Vandendriessche on 15/03/13.
+//  Copyright (c) 2013 Bart Vandendriessche. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* No comment provided by engineer. */
+"Now" = "Noww";
+
+/* No comment provided by engineer. */
+" days ago" = " days ago";
+
+/* No comment provided by engineer. */
+" hour ago" = " hour ago";
+
+/* No comment provided by engineer. */
+" hours ago" = " hours ago";
+
+/* No comment provided by engineer. */
+" minute ago" = " minute ago";
+
+/* No comment provided by engineer. */
+" minutes ago" = " minutes ago";
+
+/* This value is used in a DateFormat, the single quotes are important. */
+"'Today'" = "'Today'";
+
+/* This value is used in a DateFormat, the single quotes are important. */
+"'Tomorrow'" = "'Tomorrow'";
+
+/* This value is used in a DateFormat, the single quotes are important. */
+"'Yesterday'" = "'Yesterday'";
+
+/* No comment provided by engineer. */
+"1 day ago" = "1 day ago";
+
+/* No comment provided by engineer. */
+"1d" = "1d";
+
+/* No comment provided by engineer. */
+"d" = "d";
+
+/* No comment provided by engineer. */
+"h" = "h";
+
+/* No comment provided by engineer. */
+"m" = "m";

--- a/MHPrettyDate/en.lproj/MHPrettyDate.strings
+++ b/MHPrettyDate/en.lproj/MHPrettyDate.strings
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 
 /* No comment provided by engineer. */
-"Now" = "Noww";
+"Now" = "Now";
 
 /* No comment provided by engineer. */
 " days ago" = " days ago";

--- a/MHPrettyDate/nl.lproj/MHPrettyDate.strings
+++ b/MHPrettyDate/nl.lproj/MHPrettyDate.strings
@@ -1,0 +1,68 @@
+//
+//  MHPrettyDate.strings
+//  MHPrettyDate
+//
+//  Created by Bart Vandendriessche on 15/03/13.
+//  Copyright (c) 2013 Bart Vandendriessche. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* No comment provided by engineer. */
+"Now" = "Nu";
+
+/* No comment provided by engineer. */
+" days ago" = " dagen geleden";
+
+/* No comment provided by engineer. */
+" hour ago" = " uur geleden";
+
+/* No comment provided by engineer. */
+" hours ago" = " uren geleden";
+
+/* No comment provided by engineer. */
+" minute ago" = " minuut geleden";
+
+/* No comment provided by engineer. */
+" minutes ago" = " minuten geleden";
+
+/* This value is used in a DateFormat, the single quotes are important. */
+"'Today'" = "'Vandaag'";
+
+/* This value is used in a DateFormat, the single quotes are important. */
+"'Tomorrow'" = "'Morgen'";
+
+/* This value is used in a DateFormat, the single quotes are important. */
+"'Yesterday'" = "'Gisteren'";
+
+/* No comment provided by engineer. */
+"1 day ago" = "1 dag geleden";
+
+/* No comment provided by engineer. */
+"1d" = "1d";
+
+/* No comment provided by engineer. */
+"d" = "d";
+
+/* No comment provided by engineer. */
+"h" = "u";
+
+/* No comment provided by engineer. */
+"m" = "m";
+
+


### PR DESCRIPTION
I replaced all hardcoded strings with NSLocalizedStringFromTable and added English and Dutch MHPrettyDate.strings files.

I also added 2 extra public methods to allow people to provide their preferred NSDateFormatter for dates and times that are not stringified (instead of the hardcoded MM/dd/yyyy).

I also updated the .podspec to register the *.lproj files as resources.
