### PR TITLE
Safely traverse date boundaries after singleton instantiation.

### DIFF
--- a/MHPrettyDate.xcodeproj/project.pbxproj
+++ b/MHPrettyDate.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		CCEAF12516F3305C0049549E /* MHPrettyDate.strings in Resources */ = {isa = PBXBuildFile; fileRef = CCEAF12116F328480049549E /* MHPrettyDate.strings */; };
 		CCEAF12B16F3354E0049549E /* MHPrettyDate.strings in Resources */ = {isa = PBXBuildFile; fileRef = CCEAF12116F328480049549E /* MHPrettyDate.strings */; };
+		D0F36A7A1799BE2D00F76C70 /* NSDate+Mock.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F36A781799BE2C00F76C70 /* NSDate+Mock.m */; };
 		E9DC15FD15FBDF2600C594E6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9DC15FC15FBDF2600C594E6 /* Foundation.framework */; };
 		E9DC160215FBDF2600C594E6 /* MHPrettyDate.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E9DC160115FBDF2600C594E6 /* MHPrettyDate.h */; };
 		E9DC160415FBDF2600C594E6 /* MHPrettyDate.m in Sources */ = {isa = PBXBuildFile; fileRef = E9DC160315FBDF2600C594E6 /* MHPrettyDate.m */; };
@@ -51,8 +52,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		CCEAF12016F328480049549E /* en */ = {isa = PBXFileReference; lastKnownFileType = file; name = en; path = en.lproj/MHPrettyDate.strings; sourceTree = "<group>"; };
-		CCEAF12216F329270049549E /* nl */ = {isa = PBXFileReference; lastKnownFileType = file; name = nl; path = nl.lproj/MHPrettyDate.strings; sourceTree = "<group>"; };
+		CCEAF12016F328480049549E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/MHPrettyDate.strings; sourceTree = "<group>"; };
+		CCEAF12216F329270049549E /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/MHPrettyDate.strings; sourceTree = "<group>"; };
+		D0F36A781799BE2C00F76C70 /* NSDate+Mock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+Mock.m"; sourceTree = "<group>"; };
+		D0F36A791799BE2D00F76C70 /* NSDate+Mock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+Mock.h"; sourceTree = "<group>"; };
 		E93DEE6D161AD591005B9E19 /* MHPrettyDateExampleApp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = MHPrettyDateExampleApp.xcodeproj; path = MHPrettyDateExampleApp/MHPrettyDateExampleApp.xcodeproj; sourceTree = "<group>"; };
 		E9DC15F915FBDF2600C594E6 /* libMHPrettyDate.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMHPrettyDate.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9DC15FC15FBDF2600C594E6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -151,6 +154,8 @@
 		E9DC161315FBDF2600C594E6 /* MHPrettyDateTests */ = {
 			isa = PBXGroup;
 			children = (
+				D0F36A781799BE2C00F76C70 /* NSDate+Mock.m */,
+				D0F36A791799BE2D00F76C70 /* NSDate+Mock.h */,
 				E9DC161915FBDF2600C594E6 /* MHPrettyDateTests.h */,
 				E9DC161A15FBDF2600C594E6 /* MHPrettyDateTests.m */,
 				E9DC161415FBDF2600C594E6 /* Supporting Files */,
@@ -301,6 +306,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E9DC161B15FBDF2600C594E6 /* MHPrettyDateTests.m in Sources */,
+				D0F36A7A1799BE2D00F76C70 /* NSDate+Mock.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MHPrettyDate/MHPrettyDate.m
+++ b/MHPrettyDate/MHPrettyDate.m
@@ -67,6 +67,14 @@
     return _singleton;
 }
 
+- (void)clearCache
+{
+    _tomorrow = nil;
+    _today = nil;
+    _yesterday = nil;
+    _weekAgo = nil;
+}
+
 #pragma mark - worker methods
 
 // this is a worker method
@@ -294,8 +302,16 @@
 // today is read/write (write is for testing only)
 //
 
+- (void)sanitize
+{
+    if (![self isSameDay:_today as:[NSDate date]]) {
+        [self clearCache];
+    }
+}
+
 -(NSDate*) today
 {
+    [self sanitize];
     if (!_today)
     {
         _today = [self normalizeDate:[NSDate date]];
@@ -306,6 +322,7 @@
 // yesterday is today minus 1 day
 -(NSDate*) yesterday
 {
+    [self sanitize];
     if (!_yesterday)
     {
         NSDateComponents* comps = [[NSDateComponents alloc] init];
@@ -318,6 +335,7 @@
 // yesterday is today minus 1 day
 -(NSDate*) weekAgo
 {
+    [self sanitize];
     if (!_weekAgo)
     {
         NSDateComponents* comps = [[NSDateComponents alloc] init];
@@ -330,6 +348,7 @@
 // tomorrow is today plus 1 day
 -(NSDate*) tomorrow
 {
+    [self sanitize];
     if (!_tomorrow)
     {
         NSDateComponents* comps = [[NSDateComponents alloc] init];

--- a/MHPrettyDate/MHPrettyDate.m
+++ b/MHPrettyDate/MHPrettyDate.m
@@ -298,10 +298,6 @@
 
 // TODO: these methods can be refactored
 
-//
-// today is read/write (write is for testing only)
-//
-
 - (void)sanitize
 {
     if (_today) {
@@ -310,6 +306,10 @@
         }
     }
 }
+
+//
+// today is read/write (write is for testing only)
+//
 
 -(NSDate*) today
 {

--- a/MHPrettyDate/MHPrettyDate.m
+++ b/MHPrettyDate/MHPrettyDate.m
@@ -304,8 +304,10 @@
 
 - (void)sanitize
 {
-    if (![self isSameDay:_today as:[NSDate date]]) {
-        [self clearCache];
+    if (_today) {
+        if (![self isSameDay:_today as:[NSDate date]]) {
+            [self clearCache];
+        }
     }
 }
 

--- a/MHPrettyDateTests/MHPrettyDateTests.m
+++ b/MHPrettyDateTests/MHPrettyDateTests.m
@@ -25,6 +25,7 @@
 
 #import "MHPrettyDateTests.h"
 #import "MHPrettyDate.h"
+#import "NSDate+Mock.h"
 
 //@implementation MHPrettyDate (Testing)
 //@end
@@ -91,6 +92,48 @@ static NSCalendar* __sCalendar;
     STAssertFalse([MHPrettyDate isPastDate:compareDate], nil);
    
    [self printDate: compareDate];
+}
+
+- (void)testCompareOverDateChange
+{
+    NSDate* now = [NSDate date];
+    
+    NSDateComponents* comps = [[NSDateComponents alloc] init];
+    [comps setDay: 1];
+    NSDate* compareDate = [__sCalendar dateByAddingComponents:comps toDate:now options:0];
+    
+    NSLog(@"tomorrow is %@", compareDate);
+    
+    STAssertFalse([MHPrettyDate isToday:compareDate], nil);
+    STAssertTrue([MHPrettyDate isTomorrow: compareDate], nil);
+    STAssertFalse([MHPrettyDate isYesterday: compareDate], nil);
+    STAssertTrue([MHPrettyDate willMakePretty:compareDate], nil);
+    STAssertTrue([MHPrettyDate isFutureDate:compareDate], nil);
+    STAssertFalse([MHPrettyDate isPastDate:compareDate], nil);
+
+    // Bump the current date.
+
+    [NSDate setMockDate:compareDate];
+    
+    STAssertTrue([MHPrettyDate isToday:compareDate], nil);
+    STAssertFalse([MHPrettyDate isTomorrow: compareDate], nil);
+    STAssertFalse([MHPrettyDate isYesterday: compareDate], nil);
+    STAssertTrue([MHPrettyDate willMakePretty:compareDate], nil);
+    STAssertFalse([MHPrettyDate isFutureDate:compareDate], nil);
+    STAssertFalse([MHPrettyDate isPastDate:compareDate], nil);
+
+    [NSDate setMockDate:[__sCalendar dateByAddingComponents:comps toDate:[NSDate date] options:0]];
+
+    // Bump it again.
+
+    STAssertFalse([MHPrettyDate isToday:compareDate], nil);
+    STAssertFalse([MHPrettyDate isTomorrow: compareDate], nil);
+    STAssertTrue([MHPrettyDate isYesterday: compareDate], nil);
+    STAssertTrue([MHPrettyDate willMakePretty:compareDate], nil);
+    STAssertFalse([MHPrettyDate isFutureDate:compareDate], nil);
+    STAssertTrue([MHPrettyDate isPastDate:compareDate], nil);
+    
+    [NSDate setMockDate:nil];
 }
 
 - (void)testCompareYesterday

--- a/MHPrettyDateTests/NSDate+Mock.h
+++ b/MHPrettyDateTests/NSDate+Mock.h
@@ -1,0 +1,16 @@
+//
+//  NSDate+Mock.h
+//  Whistle
+//
+//  Created by Justin Middleton on 7/16/13.
+//  Copyright (c) 2013 whistle. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSDate (Mock)
+
++ (void) setMockDate:(NSDate *)date;
+
+@end
+

--- a/MHPrettyDateTests/NSDate+Mock.m
+++ b/MHPrettyDateTests/NSDate+Mock.m
@@ -1,0 +1,36 @@
+//
+//  NSDate+Mock.m
+//  Whistle
+//
+//  Created by Justin Middleton on 7/16/13.
+//  Copyright (c) 2013 whistle. All rights reserved.
+//
+
+#import "NSDate+Mock.h"
+#import <objc/runtime.h>
+
+@implementation NSDate (Mock)
+
+static NSDate *_mockDate;
+
++ (void)load
+{
+    Method originalDate = class_getClassMethod(self, @selector(date));
+    Method mockDate = class_getClassMethod(self, @selector(mockDate));
+    method_exchangeImplementations(originalDate, mockDate);
+}
+
++ (NSDate *)mockDate
+{
+    if (_mockDate) {
+        return _mockDate;
+    }
+    return [self mockDate];
+}
+
++ (void)setMockDate:(NSDate *)date
+{
+    _mockDate = date;
+}
+
+@end


### PR DESCRIPTION
Ensure that the cached _today, _tomorrow, etc., values are evicted prior to performing new calculations with them if _today is no longer in the same day as [NSDate date].
